### PR TITLE
Add `IV_{LIB,HEADERS,BIN}_INSTALL_DIR`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,9 +60,17 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "CYGWIN")
   set(CYGWIN 1)
 endif()
 
-# set up libdir
-if(NOT DEFINED LIB_INSTALL_DIR)
-    set(LIB_INSTALL_DIR ${CMAKE_INSTALL_PREFIX}/lib)
+# set up installation dirs
+if(NOT DEFINED IV_LIB_INSTALL_DIR)
+    set(IV_LIB_INSTALL_DIR ${CMAKE_INSTALL_PREFIX}/lib)
+endif()
+
+if(NOT DEFINED IV_HEADERS_INSTALL_DIR)
+    set(IV_HEADERS_INSTALL_DIR ${CMAKE_INSTALL_PREFIX}/include)
+endif()
+
+if(NOT DEFINED IV_BIN_INSTALL_DIR)
+    set(IV_BIN_INSTALL_DIR ${CMAKE_INSTALL_PREFIX}/bin)
 endif()
 
 # =============================================================================
@@ -165,10 +173,10 @@ add_subdirectory(src/bin)
 # =============================================================================
 # Install binaries and headers
 # =============================================================================
-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/src/include/ DESTINATION include)
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/src/include/ DESTINATION "${IV_HEADERS_INSTALL_DIR}")
 if(NOT IV_AS_SUBPROJECT)
-    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/cmake/iv-config.cmake DESTINATION ${LIB_INSTALL_DIR}/cmake/iv)
-    install(EXPORT iv DESTINATION ${LIB_INSTALL_DIR}/cmake/iv)
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/cmake/iv-config.cmake DESTINATION ${IV_LIB_INSTALL_DIR}/cmake/iv)
+    install(EXPORT iv DESTINATION ${IV_LIB_INSTALL_DIR}/cmake/iv)
 endif()
 
 # =============================================================================

--- a/src/bin/CMakeLists.txt
+++ b/src/bin/CMakeLists.txt
@@ -14,7 +14,7 @@ endif()
 set(IDEMO_SOURCE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/idemo/main.cpp ${_ivx11})
 add_executable(idemo ${IDEMO_SOURCE_FILES})
 target_link_libraries(idemo interviews ${X11_LIBRARIES})
-install(TARGETS idemo DESTINATION bin)
+install(TARGETS idemo DESTINATION ${IV_BIN_INSTALL_DIR}/bin)
 
 # =============================================================================
 # iclass
@@ -66,6 +66,6 @@ endif()
 # Install various targets
 # =============================================================================
 if(NOT IV_WINDOWS_BUILD)
-  install(TARGETS iclass DESTINATION bin)
-  install(TARGETS idraw DESTINATION bin)
+    install(TARGETS iclass DESTINATION ${IV_BIN_INSTALL_DIR}/bin)
+    install(TARGETS idraw DESTINATION ${IV_BIN_INSTALL_DIR}/bin)
 endif()

--- a/src/bin/CMakeLists.txt
+++ b/src/bin/CMakeLists.txt
@@ -14,7 +14,7 @@ endif()
 set(IDEMO_SOURCE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/idemo/main.cpp ${_ivx11})
 add_executable(idemo ${IDEMO_SOURCE_FILES})
 target_link_libraries(idemo interviews ${X11_LIBRARIES})
-install(TARGETS idemo DESTINATION ${IV_BIN_INSTALL_DIR}/bin)
+install(TARGETS idemo DESTINATION ${IV_BIN_INSTALL_DIR})
 
 # =============================================================================
 # iclass
@@ -66,6 +66,6 @@ endif()
 # Install various targets
 # =============================================================================
 if(NOT IV_WINDOWS_BUILD)
-    install(TARGETS iclass DESTINATION ${IV_BIN_INSTALL_DIR}/bin)
-    install(TARGETS idraw DESTINATION ${IV_BIN_INSTALL_DIR}/bin)
+    install(TARGETS iclass DESTINATION ${IV_BIN_INSTALL_DIR})
+    install(TARGETS idraw DESTINATION ${IV_BIN_INSTALL_DIR})
 endif()

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -438,9 +438,9 @@ if (IV_ENABLE_X11_DYNAMIC)
     set_property(TARGET ivx11dynam PROPERTY POSITION_INDEPENDENT_CODE ON)
     install(TARGETS ivx11dynam
         EXPORT iv
-        DESTINATION lib
+        DESTINATION ${IV_LIB_INSTALL_DIR}
         INCLUDES
-        DESTINATION $<INSTALL_INTERFACE:include>)
+        DESTINATION ${IV_HEADERS_INSTALL_DIR})
 endif()
 
 # =============================================================================
@@ -491,23 +491,23 @@ endif()
 # =============================================================================
 # Install targets
 # =============================================================================
-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/app-defaults/ DESTINATION share/app-defaults)
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/app-defaults/ DESTINATION ${IV_LIB_INSTALL_DIR}/share/app-defaults)
 
 if(NOT IV_WINDOWS_BUILD)
   install(TARGETS interviews
           EXPORT iv
-          DESTINATION ${LIB_INSTALL_DIR}
+          DESTINATION ${IV_LIB_INSTALL_DIR}
           INCLUDES
-          DESTINATION $<INSTALL_INTERFACE:include>)
+          DESTINATION ${IV_HEADERS_INSTALL_DIR})
   install(TARGETS unidraw
           EXPORT iv
-          DESTINATION ${LIB_INSTALL_DIR}
+          DESTINATION ${IV_LIB_INSTALL_DIR}
           INCLUDES
-          DESTINATION $<INSTALL_INTERFACE:include>)
+          DESTINATION ${IV_HEADERS_INSTALL_DIR})
 else()
   install(TARGETS interviews
           EXPORT iv
-          DESTINATION lib
+          DESTINATION ${IV_LIB_INSTALL_DIR}
           INCLUDES
-          DESTINATION $<INSTALL_INTERFACE:include>)
+          DESTINATION ${IV_HEADERS_INSTALL_DIR})
 endif()


### PR DESCRIPTION
This is a prerequisite for https://github.com/neuronsimulator/nrn/pull/3350, since Python wheels and the regular CMake install do not have the same directory layout. At the moment, the "different directory layout depending on the build method" problem is handled in NEURON via some `setup.py` hackery, but once https://github.com/neuronsimulator/nrn/pull/3350 is merged, it will make things much easier.